### PR TITLE
Split Apache conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# sudweb.fr dotfiles
+
+These files control how the website is configured over the Web.
+
+These are the current Apache *Virtual host directives*:
+
+```
+DocumentRoot /home/sudweb/www
+
+Include /home/sudweb/dotfiles/apache.conf
+Include /home/sudweb/dotfiles/apache-sudweb.conf
+Include /home/sudweb/dotfiles/apache-proxies.conf
+```
+
+You can control them by submitting a *pull request*:
+
+1. [apache.conf](apache.conf)
+2. [apache-sudweb.conf](apache-sudweb.conf)
+3. [apache-proxies.conf](apache-proxies.conf)
+
+# Hosting
+
+Hosting is generously provided by [Alwaysdata](https://alwaysdata.com).

--- a/apache-proxies.conf
+++ b/apache-proxies.conf
@@ -1,0 +1,18 @@
+# Reverse proxies for the mass
+<IfModule mod_proxy.c>
+  ProxyPreserveHost Off
+  ProxyRequests Off
+  ProxyVia Off
+
+  # Blog
+  ProxyPass /blog/ http://sudweb.github.io/blog/
+  ProxyPassReverse /blog/ http://sudweb.github.io/blog/
+
+  # Talks Review
+  ProxyPass /talks/ http://sudweb.github.io/talks/
+  ProxyPassReverse /talks/ http://sudweb.github.io/talks/
+
+  # 2016 edition
+  ProxyPass /2016 http://sudweb.github.io/2016/
+  ProxyPassReverse /2016 http://sudweb.github.io/2016/
+</IfModule>

--- a/apache-sudweb.conf
+++ b/apache-sudweb.conf
@@ -1,0 +1,25 @@
+# DirectoryIndex
+DirectoryIndex index.html index.php
+
+RewriteEngine on
+
+# Redirect to current edition
+RedirectMatch 302 ^/$ https://sudweb.fr/2016/
+
+# Redirect old links to 2011 static site
+RedirectPermanent /category https://sudweb.fr/2011/category
+RedirectPermanent /pages https://sudweb.fr/2011/pages
+RedirectPermanent /tag https://sudweb.fr/2011/tag
+RedirectPermanent /post https://sudweb.fr/2011/post
+RedirectPermanent /feed/atom https://sudweb.fr/blog/feed
+RedirectPermanent /2012/feed https://sudweb.fr/blog/feed
+
+# Redirect old static site
+RewriteRule ^index.htm$ / [L,R=301]
+
+# Remove index.php from url
+RewriteCond %{ENV:REDIRECT_STATUS} !200
+RewriteRule ^index.php$ / [L,R=301]
+
+RewriteCond %{ENV:REDIRECT_STATUS} !200
+RewriteRule ^index.php(.*)$ $1 [L,R=301]

--- a/apache.conf
+++ b/apache.conf
@@ -1,33 +1,3 @@
-# DirectoryIndex
-DirectoryIndex index.html index.php
-
-RewriteEngine on
-
-# Redirect to current edition 
-RedirectMatch 302 ^/$ https://sudweb.fr/2016/
-
-# Redirect old links to 2011 static site
-RedirectPermanent /category http://sudweb.fr/2011/category
-RedirectPermanent /pages http://sudweb.fr/2011/pages
-RedirectPermanent /tag http://sudweb.fr/2011/tag
-RedirectPermanent /post http://sudweb.fr/2011/post
-RedirectPermanent /feed/atom http://sudweb.fr/blog/feed
-RedirectPermanent /2012/feed http://sudweb.fr/blog/feed
-
-# Redirect old static site 
-RewriteRule ^index.htm$ / [L,R=301]
-
-# Remove index.php from url
-RewriteCond %{ENV:REDIRECT_STATUS} !200
-RewriteRule ^index.php$ / [L,R=301]
-
-RewriteCond %{ENV:REDIRECT_STATUS} !200
-RewriteRule ^index.php(.*)$ $1 [L,R=301]
-
-<IfModule mod_headers.c>
-    Header set Strict-Transport-Security max-age=16070400;
-</IfModule>
-
 # ----------------------------------------------------------------------
 # Better website experience for IE users
 # ----------------------------------------------------------------------
@@ -231,10 +201,13 @@ FileETag None
 
 # ----------------------------------------------------------------------
 
+<IfModule mod_headers.c>
+    Header set Strict-Transport-Security max-age=16070400;
+</IfModule>
+
 <IfModule mod_rewrite.c>
   RewriteCond %{HTTP:X-Forwarded-Proto} !https
-  # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-  RewriteRule ^ https://sudweb.fr%{REQUEST_URI} [R=301,L]
+  RewriteRule ^(.*)$ https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]
 </IfModule>
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
This way rules are applied at the same level of the ProxyPass.

Otherwise ProxyPass rules were taking precendence over the global `.htaccess` file.
Thus preventing performance tweaks and https redirects.

closes sudweb/2016#128
